### PR TITLE
Fixed crypto errors for some users

### DIFF
--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -125,7 +125,9 @@ class Snapchat extends SnapchatAgent {
 
 	public function getOAuthToken()
 	{
-		$passwordJSON = file_get_contents("https://tekno.pw/snapchat_password.php");
+		$ch = curl_init();
+		curl_setopt_array($ch, array(CURLOPT_RETURNTRANSFER => 1, CURLOPT_URL => 'https://tekno.pw/snapchat_password.php', CURLOPT_CAINFO => dirname(__FILE__) . '/ca_bundle.crt'));
+		$passwordJSON = curl_exec($ch);
 		$loginArray = json_decode($passwordJSON, true);
 
 		$ch = curl_init();


### PR DESCRIPTION
Some users were experiencing issues with crypto not being enabled/working, so I simply rewrote one line, with curl, instead of file_get_contents.
