### PR TITLE
getMedia fix, fixed time in filename (for mac os x)

### DIFF
--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -2257,7 +2257,6 @@ class Snapchat extends SnapchatAgent {
 			{
 				if(file_exists($file . $ext))
 				{
-					if ($this->cli) echo "  skipping...\n";
 					return false;
 				}
 			}

--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -2264,65 +2264,29 @@ class Snapchat extends SnapchatAgent {
 				{
 					mkdir($path, 0777, true);
 				}
-
+				$file = $path . DIRECTORY_SEPARATOR . date("Y-m-d H-i-s", (int) ($timestamp / 1000)) . "-story-" . $media_id;
+				$extensions = array(".jpg", ".png", ".mp4", "");
+				foreach ($extensions as $ext)
+				{
+					if(file_exists($file . $ext))
+					{
+						return false;
+					}
+				}
+				
 				if(is_array($result))
 				{
 					foreach ($result as &$value)
 					{
-				    $file = $path . DIRECTORY_SEPARATOR . date("Y-m-d H-i-s", (int) ($timestamp / 1000)) . "-story-" . $media_id;
-
 						if(!file_exists($file))
 						{
-							file_put_contents($file, $value);
-							$finfo = finfo_open(FILEINFO_MIME_TYPE);
-							$finfo = finfo_file($finfo, $file);
-							switch($finfo)
-							{
-								case "image/jpeg":
-										$ext = ".jpg";
-										break;
-								case "image/png":
-										$ext = ".png";
-										break;
-								case "video/mp4";
-										$ext = ".mp4";
-										break;
-								default:
-										$ext = null;
-							}
-
-							if($ext != null)
-							{
-								rename($file, $file . $ext);
-							}
+							$this->writeToFile($file, $value);
 						}
 					}
 				}else{
-					$file = $path . DIRECTORY_SEPARATOR . date("Y-m-d H-i-s", (int) ($timestamp / 1000)) . "-story-" . $media_id;
 					if(!file_exists($file))
 					{
-						file_put_contents($file, $result);
-						$finfo = finfo_open(FILEINFO_MIME_TYPE);
-						$finfo = finfo_file($finfo, $file);
-						switch($finfo)
-						{
-							case "image/jpeg":
-									$ext = ".jpg";
-									break;
-							case "image/png":
-									$ext = ".png";
-									break;
-							case "video/mp4";
-									$ext = ".mp4";
-									break;
-							default:
-									$ext = null;
-						}
-
-						if($ext != null)
-						{
-							rename($file, $file . $ext);
-						}
+						$this->writeToFile($file, $result);
 					}
 				}
 			}

--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -2238,12 +2238,36 @@ class Snapchat extends SnapchatAgent {
 			return FALSE;
 		}
 
+		// Build path
+		if($save)
+		{
+			if ($subdir == null) {
+				$subdir = $this->username;
+			}
+
+			$path = __DIR__ . DIRECTORY_SEPARATOR . "stories" . DIRECTORY_SEPARATOR . $subdir . DIRECTORY_SEPARATOR .  $from;
+
+			if(!file_exists($path))
+			{
+				mkdir($path, 0777, true);
+			}
+			$file = $path . DIRECTORY_SEPARATOR . date("Y-m-d H-i-s", (int) ($timestamp / 1000)) . "-story-" . $media_id;
+			$extensions = array(".jpg", ".png", ".mp4", "");
+			foreach ($extensions as $ext)
+			{
+				if(file_exists($file . $ext))
+				{
+					if ($this->cli) echo "  skipping...\n";
+					return false;
+				}
+			}
+		}
+
 		// Retrieve encrypted story and decrypt.
 		$blob = parent::get('/bq/story_blob?story_id=' . $media_id);
 
 		if(!empty($blob))
 		{
-
 			$result = parent::decryptCBC($blob, $key, $iv);
 
 			if(parent::isCompressed(substr($result, 0, 2)))
@@ -2253,27 +2277,6 @@ class Snapchat extends SnapchatAgent {
 
 			if($save)
 			{
-
-				if ($subdir == null) {
-					$subdir = $this->username;
-				}
-
-				$path = __DIR__ . DIRECTORY_SEPARATOR . "stories" . DIRECTORY_SEPARATOR . $subdir . DIRECTORY_SEPARATOR .  $from;
-
-				if(!file_exists($path))
-				{
-					mkdir($path, 0777, true);
-				}
-				$file = $path . DIRECTORY_SEPARATOR . date("Y-m-d H-i-s", (int) ($timestamp / 1000)) . "-story-" . $media_id;
-				$extensions = array(".jpg", ".png", ".mp4", "");
-				foreach ($extensions as $ext)
-				{
-					if(file_exists($file . $ext))
-					{
-						return false;
-					}
-				}
-				
 				if(is_array($result))
 				{
 					foreach ($result as &$value)
@@ -2283,7 +2286,9 @@ class Snapchat extends SnapchatAgent {
 							$this->writeToFile($file, $value);
 						}
 					}
-				}else{
+				}
+				else
+				{
 					if(!file_exists($file))
 					{
 						$this->writeToFile($file, $result);


### PR DESCRIPTION
Downloading videos with overlay works now (overlay gets saved seperately)
Media is only getting downloaded if it doesn't exist already
Reverted time seperators back to "-" (colon isn't supported in filenames on some OS including Mac OS X)
