### PR TITLE
Faster sending of messages

### DIFF
--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -705,7 +705,8 @@ class Snapchat extends SnapchatAgent {
 					$this->auth_token,
 					$timestamp,
 				),
-				$multipart = false
+				$multipart = false,
+				$debug = $this->debug
 			);
 			$resultsf = array();
 			foreach($result['data']->conversations as $convo){
@@ -780,7 +781,8 @@ class Snapchat extends SnapchatAgent {
 				$this->auth_token,
 				$timestamp,
 			),
-			$multipart = false
+			$multipart = false,
+			$debug = $this->debug
 		);
 		return $result;
 	}

--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -767,6 +767,7 @@ class Snapchat extends SnapchatAgent {
 				    'type' => 'chat_message'
 			    );
 	    }
+	    	if(count($messagesArray) <= 0) return null;
 		$messages = json_encode($messagesArray);
 		$timestamp = parent::timestamp();
 		$result = parent::post(


### PR DESCRIPTION
I reduced the number of calls to snapchat's servers for sending mass messages. This is simply done, by 1 reusing the auth data retrieved from getConversationAuth called by getConversationInfo. Additionally, getConversationInfo now requests all the usernames at once.
