### PR TITLE
getMedia video overlay, need some shine

### DIFF
--- a/src/snapchat.php
+++ b/src/snapchat.php
@@ -1870,8 +1870,28 @@ class Snapchat extends SnapchatAgent {
 			{
 				foreach ($result as $key => $value)
 				{
-					$this->writeToFile($file, $value);
+					$newfile=$this->writeToFile($file, $value);
+					$files=$newfile;
 				}
+				// sometimes the array is createed with blanck values.
+			$files=array_values(array_diff($files,array( "" )));
+
+			$path_parts = pathinfo($video);
+			$orignial= $path_parts['filename'].'.' . $path_parts['extension'];
+			$orignial=$path_parts['dirname']."/".$orignial;
+			
+			$name=$path_parts['filename'] . "-" . '.' . $path_parts['extension'];
+			$out= $path_parts['dirname']."/".$name;
+			
+			$videoSize = shell_exec("ffprobe -v error -select_streams v:0 -show_entries stream=width,height \-of default=nokey=1:noprint_wrappers=1 $files[0]");
+			$videoSize = array_filter(explode("\n", $videoSize));
+			
+			shell_exec("ffmpeg -loglevel panic -y -i $files[1] -vf scale=$videoSize[0]:$videoSize[1] $files[1]");
+			shell_exec("ffmpeg -loglevel panic -y -i $files[0] -i $files[1] -strict -2 -filter_complex overlay -c:a copy -flags global_header $out");
+			unlink($files[1]);
+			
+			rename($out,$orignial);
+
 			}
 			else
 			{


### PR DESCRIPTION
When retrieving received snaps, if video has overlay, the overlay and video are saved separately, thus I'd like it overlayed.

I tried using the same code as the getStory recent pull but I found that, at least in my case, FFmpeg can´t export over the input file path.
Therefore I have to create a new file path as output, and then rename the output to the original file path.
Nevertheless I'm sure a some other shorter method can be used to set the entire original file path and the output path. This is the way I found.
